### PR TITLE
Update shrimp-paste info

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ These CNAME aliases are the easiest way to access our resources. If you need som
 * macos.arm64.kernel.cafe (8-core, 16GB)
 * ubuntu.arm64.kernel.cafe (8-core, 32GB)
 
-### ppc64le (POWER9)
+### ppc64 (POWER9)
 
-* fedora.ppc64le.kernel.cafe (8-core, 64GB): hosted in Australia by <a href="https://github.com/runlevel5">@runlevel5</a>
+* voidlinux.ppc64.kernel.cafe (8-core, 8GB): hosted in Australia by <a href="https://github.com/runlevel5">@runlevel5</a>
 
 ## Arriving by March 1st
 
@@ -75,6 +75,10 @@ These CNAME aliases are the easiest way to access our resources. If you need som
 * smartos.amd64.kernel.cafe (4-core, 32GB)
 * netbsd.amd64.kernel.cafe (2-core, 4GB)
 * dragonflybsd.amd64.kernel.cafe (2-core, 4GB)
+
+### ppc64le (POWER9)
+
+* fedora.ppc64le.kernel.cafe (8-core, 8GB): hosted in Australia by <a href="https://github.com/runlevel5">@runlevel5</a>
 
 ## Arriving later
 

--- a/nodes/nodes.yaml
+++ b/nodes/nodes.yaml
@@ -69,18 +69,18 @@ nodes:
       memory: 64GB    
     
   - name: shrimp-paste
-    arch: ppc64le
+    arch: ppc64
     os: Linux
-    distro: Fedora
+    distro: Void
     ip: "2401:d002:4102:900:f2b1:734c:c317:1c42"
     owner: tle
     exclude_users:
       - tle
     location: Melbourne, AU
     hw:
-      desc: Raptor Blackbird (POWER9)
+      desc: KVM/QEM on Raptor Blackbird (POWER9) host
       cores: 8
-      memory: 64GB    
+      memory: 8GB
     
   - name: debbie
     arch: amd64


### PR DESCRIPTION
shrimp-paste host is now being hosted as VM with QEMU/KVM under POWER9 Raptor Blackbird host.

I will be adding a new node for ppc64le.